### PR TITLE
Add 'init' command to .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@ image:
 
 tasks:
   - name: Next.js Server
+    init: npm install
     command: |
         cd nextjs-blog
         npm run dev


### PR DESCRIPTION
Having an `init` script allows Gitpod to run initialization commands ahead-of-time, even before you open workspaces (see [Prebuilds](https://www.gitpod.io/docs/prebuilds/)).

Given that the Gitpod app focuses mainly on Prebuilds, I think maybe adding an `init` script can help make it work. 🤞 